### PR TITLE
Add arXiv MCP Server integration

### DIFF
--- a/clients/Gradio/mcp_servers/arxiv/README.md
+++ b/clients/Gradio/mcp_servers/arxiv/README.md
@@ -1,0 +1,75 @@
+# arXiv MCP Server Integration
+
+This integration allows you to use the arXiv MCP Server with the Gradio client. The arXiv MCP Server provides tools for searching, downloading, and reading arXiv papers.
+
+## Prerequisites
+
+- Python 3.10 or higher
+- Node.js 16 or higher
+
+## Installation
+
+1. Install the arxiv-mcp-server package:
+   ```bash
+   pip install arxiv-mcp-server
+   ```
+
+2. Make sure the arxiv-stdio.js script is executable:
+   ```bash
+   chmod +x arxiv-stdio.js
+   ```
+
+## Configuration
+
+Add the arxiv server to your server_config.json file:
+
+```json
+{
+  "mcpServers": {
+    "arxiv": {
+      "command": "node",
+      "args": [
+        "clients/Gradio/mcp_servers/arxiv/arxiv-stdio.js"
+      ]
+    }
+  }
+}
+```
+
+## Available Tools
+
+The arXiv MCP Server provides the following tools:
+
+1. **search_papers**: Search for papers on arXiv
+   - Parameters:
+     - query: The search query
+     - max_results: Maximum number of results to return (default: 10)
+
+2. **download_paper**: Download a paper from arXiv
+   - Parameters:
+     - paper_id: The arXiv ID of the paper
+
+3. **list_papers**: List downloaded papers
+   - Parameters: None
+
+4. **read_paper**: Read a downloaded paper
+   - Parameters:
+     - paper_id: The arXiv ID of the paper
+
+## Example Usage
+
+Here are some example prompts to use with the arXiv MCP Server:
+
+- "Search for papers about large language models"
+- "Download the paper with ID 2303.08774"
+- "List all downloaded papers"
+- "Read the paper with ID 2303.08774"
+
+## Troubleshooting
+
+If you encounter any issues, make sure:
+
+1. The arxiv-mcp-server package is installed
+2. The arxiv-stdio.js script is executable
+3. The server_config.json file is correctly configured
+4. You have an active internet connection to access arXiv

--- a/clients/Gradio/mcp_servers/arxiv/arxiv-stdio.js
+++ b/clients/Gradio/mcp_servers/arxiv/arxiv-stdio.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+const { createInterface } = require('readline');
+
+// Spawn the Python process
+const pythonProcess = spawn('arxiv-mcp-server', [], {
+  stdio: ['pipe', 'pipe', 'pipe']
+});
+
+// Set up readline interface for stdin
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  terminal: false
+});
+
+// Forward stdin to the Python process
+rl.on('line', (line) => {
+  pythonProcess.stdin.write(line + '\n');
+});
+
+// Forward stdout from the Python process
+pythonProcess.stdout.on('data', (data) => {
+  process.stdout.write(data);
+});
+
+// Forward stderr from the Python process
+pythonProcess.stderr.on('data', (data) => {
+  console.error(`stderr: ${data}`);
+});
+
+// Handle process exit
+pythonProcess.on('close', (code) => {
+  console.error(`child process exited with code ${code}`);
+  process.exit(code);
+});
+
+// Handle SIGINT (Ctrl+C)
+process.on('SIGINT', () => {
+  pythonProcess.kill('SIGINT');
+});

--- a/clients/Gradio/mcp_servers/arxiv/package.json
+++ b/clients/Gradio/mcp_servers/arxiv/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "arxiv-mcp-server-wrapper",
+  "version": "1.0.0",
+  "description": "Node.js wrapper for the arXiv MCP Server",
+  "main": "arxiv-stdio.js",
+  "scripts": {
+    "start": "node arxiv-stdio.js"
+  },
+  "dependencies": {
+    "node-fetch": "^2.6.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "private": true
+}

--- a/clients/Gradio/mcp_servers/arxiv/requirements.txt
+++ b/clients/Gradio/mcp_servers/arxiv/requirements.txt
@@ -1,0 +1,2 @@
+arxiv-mcp-server>=0.2.8
+node-fetch>=2.6.0

--- a/clients/Gradio/mcp_servers/arxiv/server_config.example.json
+++ b/clients/Gradio/mcp_servers/arxiv/server_config.example.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "demo-tools": {
+      "command": "node",
+      "args": [
+        "clients/Gradio/mcp_servers/demo-mcp-server/demo-tools-stdio.js"
+      ]
+    },
+    "arxiv": {
+      "command": "node",
+      "args": [
+        "clients/Gradio/mcp_servers/arxiv/arxiv-stdio.js"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Add arXiv MCP Server Integration

This pull request adds integration with the arXiv MCP Server, which provides tools for searching, downloading, and reading arXiv papers.

### Features Added:
- Search for papers on arXiv
- Download papers from arXiv
- List downloaded papers
- Read downloaded papers

### Files Added:
- \`clients/Gradio/mcp_servers/arxiv/arxiv-stdio.js\`: Node.js wrapper for the arXiv MCP Server
- \`clients/Gradio/mcp_servers/arxiv/package.json\`: Node.js dependencies
- \`clients/Gradio/mcp_servers/arxiv/README.md\`: Documentation
- \`clients/Gradio/mcp_servers/arxiv/requirements.txt\`: Python dependencies
- \`clients/Gradio/mcp_servers/arxiv/server_config.example.json\`: Example configuration

### How to Use:
1. Install the arxiv-mcp-server package: \`pip install arxiv-mcp-server\`
2. Add the arxiv server to your server_config.json file
3. Restart the Gradio client

### Dependencies:
- Python 3.10 or higher
- Node.js 16 or higher
- arxiv-mcp-server package
- node-fetch package"